### PR TITLE
Refactor: Remove tabbed navigation from distance pages

### DIFF
--- a/chebyshevDistance.html
+++ b/chebyshevDistance.html
@@ -21,19 +21,8 @@
       }
       @import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap");
 
-      .tab-button {
-        transition: all 0.3s ease;
-      }
-      .tab-button.active {
-        border-color: #0d9488; /* teal-600 */
-        color: #0d9488;
-        font-weight: 600;
-      }
       .content-section {
-        display: none;
-      }
-      .content-section.active {
-        display: block;
+        display: block; margin-bottom: 2rem;
       }
       .formula {
         font-family: "Consolas", "Courier New", Courier, monospace;
@@ -164,43 +153,10 @@
         </h1>
       </header>
 
-      <nav class="mb-8 flex flex-wrap justify-center gap-2 sm:gap-4">
-        <button
-          class="tab-button active py-2 px-4 border-b-2 border-transparent hover:border-teal-500 hover:text-teal-600 rounded-t-md"
-          data-tab="definicao"
-        >
-          Definição
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-teal-500 hover:text-teal-600 rounded-t-md"
-          data-tab="formula"
-        >
-          Fórmula
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-teal-500 hover:text-teal-600 rounded-t-md"
-          data-tab="intuicao"
-        >
-          Intuição (Xadrez)
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-teal-500 hover:text-teal-600 rounded-t-md"
-          data-tab="aplicacoes"
-        >
-          Aplicações Práticas
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-teal-500 hover:text-teal-600 rounded-t-md"
-          data-tab="visualizador"
-        >
-          Visualizador Interativo
-        </button>
-      </nav>
-
       <main>
         <section
           id="definicao"
-          class="content-section active bg-white p-6 rounded-lg shadow-md"
+          class="content-section bg-white p-6 rounded-lg shadow-md"
         >
           <h2 class="text-2xl font-semibold text-teal-600 mb-4">
             O que é a Distância de Chebyshev?
@@ -537,26 +493,6 @@
 
     <script>
       document.addEventListener("DOMContentLoaded", function () {
-        const tabs = document.querySelectorAll(".tab-button");
-        const contentSections = document.querySelectorAll(".content-section");
-
-        tabs.forEach((tab) => {
-          tab.addEventListener("click", () => {
-            tabs.forEach((t) => t.classList.remove("active"));
-            tab.classList.add("active");
-            const targetTab = tab.getAttribute("data-tab");
-            contentSections.forEach((section) => {
-              section.classList.remove("active");
-              if (section.id === targetTab) {
-                section.classList.add("active");
-              }
-            });
-            if (targetTab === "visualizador") {
-              requestAnimationFrame(() => sizeCanvasAndDraw());
-            }
-          });
-        });
-
         document.getElementById("currentYear").textContent =
           new Date().getFullYear();
 
@@ -746,12 +682,11 @@
 
         window.addEventListener("resize", sizeCanvasAndDraw);
 
-        if (
-          document.getElementById("visualizador").classList.contains("active")
-        ) {
-          requestAnimationFrame(() => sizeCanvasAndDraw());
-        } else {
-          const p1x = parseFloat(p1xInput.value);
+        // Ensure canvas is drawn on initial load as sections are now always visible
+        requestAnimationFrame(() => sizeCanvasAndDraw());
+        // The following block is not strictly necessary anymore as the visualizador section is always "active"
+        // However, keeping it doesn't harm, and ensures the initial calculation if needed for some reason.
+        const p1x = parseFloat(p1xInput.value);
           const p1y = parseFloat(p1yInput.value);
           const p2x = parseFloat(p2xInput.value);
           const p2y = parseFloat(p2yInput.value);

--- a/correlationDistance.html
+++ b/correlationDistance.html
@@ -17,19 +17,8 @@
       }
       @import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap");
 
-      .tab-button {
-        transition: all 0.3s ease;
-      }
-      .tab-button.active {
-        border-color: #2563eb; /* blue-600 */
-        color: #2563eb;
-        font-weight: 600;
-      }
       .content-section {
-        display: none;
-      }
-      .content-section.active {
-        display: block;
+        display: block; margin-bottom: 2rem;
       }
       .canvas-container {
         position: relative;
@@ -163,43 +152,10 @@
         </h1>
       </header>
 
-      <nav class="mb-8 flex flex-wrap justify-center gap-2 sm:gap-4">
-        <button
-          class="tab-button active py-2 px-4 border-b-2 border-transparent hover:border-blue-500 hover:text-blue-600 rounded-t-md"
-          data-tab="definicao"
-        >
-          Definição
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-blue-500 hover:text-blue-600 rounded-t-md"
-          data-tab="formula"
-        >
-          Fórmula e Termos
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-blue-500 hover:text-blue-600 rounded-t-md"
-          data-tab="propriedades"
-        >
-          Propriedades
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-blue-500 hover:text-blue-600 rounded-t-md"
-          data-tab="aplicacoes"
-        >
-          Aplicações Práticas
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-blue-500 hover:text-blue-600 rounded-t-md"
-          data-tab="visualizador"
-        >
-          Visualizador Interativo
-        </button>
-      </nav>
-
       <main>
         <section
           id="definicao"
-          class="content-section active bg-white p-6 rounded-lg shadow-md"
+          class="content-section bg-white p-6 rounded-lg shadow-md"
         >
           <h2 class="text-2xl font-semibold text-blue-600 mb-4">
             O que é a Distância de Correlação?
@@ -594,23 +550,6 @@
 
     <script>
       document.addEventListener("DOMContentLoaded", function () {
-        const tabs = document.querySelectorAll(".tab-button");
-        const contentSections = document.querySelectorAll(".content-section");
-
-        tabs.forEach((tab) => {
-          tab.addEventListener("click", () => {
-            tabs.forEach((t) => t.classList.remove("active"));
-            tab.classList.add("active");
-            const targetTab = tab.getAttribute("data-tab");
-            contentSections.forEach((section) => {
-              section.classList.remove("active");
-              if (section.id === targetTab) {
-                section.classList.add("active");
-              }
-            });
-          });
-        });
-
         document.getElementById("currentYearCorrelation").textContent =
           new Date().getFullYear();
 

--- a/cosineDistance.html
+++ b/cosineDistance.html
@@ -20,19 +20,8 @@
       }
       @import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap");
 
-      .tab-button {
-        transition: all 0.3s ease;
-      }
-      .tab-button.active {
-        border-color: #f97316; /* orange-500 */
-        color: #f97316;
-        font-weight: 600;
-      }
       .content-section {
-        display: none;
-      }
-      .content-section.active {
-        display: block;
+        display: block; margin-bottom: 2rem;
       }
       /* Ensure canvas is responsive and respects container */
       .canvas-container {
@@ -151,37 +140,10 @@
         </h1>
       </header>
 
-      <nav class="mb-8 flex flex-wrap justify-center gap-2 sm:gap-4">
-        <button
-          class="tab-button active py-2 px-4 border-b-2 border-transparent hover:border-orange-400 hover:text-orange-500 rounded-t-md"
-          data-tab="definicao"
-        >
-          Definição
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-orange-400 hover:text-orange-500 rounded-t-md"
-          data-tab="formula"
-        >
-          Fórmula e Termos
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-orange-400 hover:text-orange-500 rounded-t-md"
-          data-tab="aplicacoes"
-        >
-          Aplicações Práticas
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-orange-400 hover:text-orange-500 rounded-t-md"
-          data-tab="visualizador"
-        >
-          Visualizador Interativo
-        </button>
-      </nav>
-
       <main>
         <section
           id="definicao"
-          class="content-section active bg-white p-6 rounded-lg shadow-md"
+          class="content-section bg-white p-6 rounded-lg shadow-md"
         >
           <h2 class="text-2xl font-semibold text-orange-600 mb-4">
             O que é a Distância Cosseno?
@@ -514,24 +476,6 @@
 
     <script>
       document.addEventListener("DOMContentLoaded", function () {
-        const tabs = document.querySelectorAll(".tab-button");
-        const contentSections = document.querySelectorAll(".content-section");
-
-        tabs.forEach((tab) => {
-          tab.addEventListener("click", () => {
-            tabs.forEach((t) => t.classList.remove("active"));
-            tab.classList.add("active");
-
-            const targetTab = tab.getAttribute("data-tab");
-            contentSections.forEach((section) => {
-              section.classList.remove("active");
-              if (section.id === targetTab) {
-                section.classList.add("active");
-              }
-            });
-          });
-        });
-
         document.getElementById("currentYear").textContent =
           new Date().getFullYear();
 

--- a/diceDistance.html
+++ b/diceDistance.html
@@ -17,19 +17,8 @@
       }
       @import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap");
 
-      .tab-button {
-        transition: all 0.3s ease;
-      }
-      .tab-button.active {
-        border-color: #2563eb; /* blue-600 */
-        color: #2563eb;
-        font-weight: 600;
-      }
       .content-section {
-        display: none;
-      }
-      .content-section.active {
-        display: block;
+        display: block; margin-bottom: 2rem;
       }
       .formula {
         font-family: "Courier New", Courier, monospace;
@@ -147,43 +136,10 @@
         </h1>
       </header>
 
-      <nav class="mb-8 flex flex-wrap justify-center gap-2 sm:gap-4">
-        <button
-          class="tab-button active py-2 px-4 border-b-2 border-transparent hover:border-blue-500 hover:text-blue-600 rounded-t-md"
-          data-tab="definicao"
-        >
-          Definição
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-blue-500 hover:text-blue-600 rounded-t-md"
-          data-tab="formula"
-        >
-          Fórmula e Termos
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-blue-500 hover:text-blue-600 rounded-t-md"
-          data-tab="propriedades"
-        >
-          Propriedades
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-blue-500 hover:text-blue-600 rounded-t-md"
-          data-tab="aplicacoes"
-        >
-          Aplicações Práticas
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-blue-500 hover:text-blue-600 rounded-t-md"
-          data-tab="visualizador"
-        >
-          Visualizador Interativo
-        </button>
-      </nav>
-
       <main>
         <section
           id="definicao"
-          class="content-section active bg-white p-6 rounded-lg shadow-md"
+          class="content-section bg-white p-6 rounded-lg shadow-md"
         >
           <h2 class="text-2xl font-semibold text-blue-600 mb-4">
             O que é a Distância de Dice / Perda de Dice?
@@ -566,24 +522,6 @@
 
     <script>
       document.addEventListener("DOMContentLoaded", function () {
-        const tabs = document.querySelectorAll(".tab-button");
-        const contentSections = document.querySelectorAll(".content-section");
-
-        tabs.forEach((tab) => {
-          tab.addEventListener("click", () => {
-            tabs.forEach((t) => t.classList.remove("active"));
-            tab.classList.add("active");
-
-            const targetTab = tab.getAttribute("data-tab");
-            contentSections.forEach((section) => {
-              section.classList.remove("active");
-              if (section.id === targetTab) {
-                section.classList.add("active");
-              }
-            });
-          });
-        });
-
         document.getElementById("currentYearDice").textContent =
           new Date().getFullYear();
 

--- a/euclidianDistance.html
+++ b/euclidianDistance.html
@@ -18,19 +18,8 @@
       }
       @import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap");
 
-      .tab-button {
-        transition: all 0.3s ease;
-      }
-      .tab-button.active {
-        border-color: #2563eb; /* blue-600 */
-        color: #2563eb;
-        font-weight: 600;
-      }
       .content-section {
-        display: none;
-      }
-      .content-section.active {
-        display: block;
+        display: block; margin-bottom: 2rem;
       }
       .canvas-container {
         position: relative;
@@ -163,43 +152,10 @@
         </h1>
       </header>
 
-      <nav class="mb-8 flex flex-wrap justify-center gap-2 sm:gap-4">
-        <button
-          class="tab-button active py-2 px-4 border-b-2 border-transparent hover:border-blue-500 hover:text-blue-600 rounded-t-md"
-          data-tab="definicao"
-        >
-          Definição
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-blue-500 hover:text-blue-600 rounded-t-md"
-          data-tab="formula"
-        >
-          Fórmula e Termos
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-blue-500 hover:text-blue-600 rounded-t-md"
-          data-tab="propriedades"
-        >
-          Propriedades
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-blue-500 hover:text-blue-600 rounded-t-md"
-          data-tab="aplicacoes"
-        >
-          Aplicações Práticas
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-blue-500 hover:text-blue-600 rounded-t-md"
-          data-tab="visualizador"
-        >
-          Visualizador Interativo
-        </button>
-      </nav>
-
       <main>
         <section
           id="definicao"
-          class="content-section active bg-white p-6 rounded-lg shadow-md"
+          class="content-section bg-white p-6 rounded-lg shadow-md"
         >
           <h2 class="text-2xl font-semibold text-blue-600 mb-4">
             O que é a Distância Euclidiana?
@@ -557,24 +513,6 @@
 
     <script>
       document.addEventListener("DOMContentLoaded", function () {
-        const tabs = document.querySelectorAll(".tab-button");
-        const contentSections = document.querySelectorAll(".content-section");
-
-        tabs.forEach((tab) => {
-          tab.addEventListener("click", () => {
-            tabs.forEach((t) => t.classList.remove("active"));
-            tab.classList.add("active");
-
-            const targetTab = tab.getAttribute("data-tab");
-            contentSections.forEach((section) => {
-              section.classList.remove("active");
-              if (section.id === targetTab) {
-                section.classList.add("active");
-              }
-            });
-          });
-        });
-
         document.getElementById("currentYear").textContent =
           new Date().getFullYear();
 

--- a/hammingDistance.html
+++ b/hammingDistance.html
@@ -18,19 +18,8 @@
       }
       @import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap");
 
-      .tab-button {
-        transition: all 0.3s ease;
-      }
-      .tab-button.active {
-        border-color: #0d9488; /* teal-600 */
-        color: #0d9488;
-        font-weight: 600;
-      }
       .content-section {
-        display: none;
-      }
-      .content-section.active {
-        display: block;
+        display: block; margin-bottom: 2rem;
       }
       .formula {
         font-family: "Consolas", "Courier New", Courier, monospace;
@@ -150,43 +139,10 @@
         </h1>
       </header>
 
-      <nav class="mb-8 flex flex-wrap justify-center gap-2 sm:gap-4">
-        <button
-          class="tab-button active py-2 px-4 border-b-2 border-transparent hover:border-teal-500 hover:text-teal-600 rounded-t-md"
-          data-tab="definicao"
-        >
-          Definição
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-teal-500 hover:text-teal-600 rounded-t-md"
-          data-tab="formula"
-        >
-          Fórmula
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-teal-500 hover:text-teal-600 rounded-t-md"
-          data-tab="exemplo"
-        >
-          Exemplo de Cálculo
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-teal-500 hover:text-teal-600 rounded-t-md"
-          data-tab="aplicacoes"
-        >
-          Aplicações Práticas
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-teal-500 hover:text-teal-600 rounded-t-md"
-          data-tab="calculadora"
-        >
-          Calculadora Interativa
-        </button>
-      </nav>
-
       <main>
         <section
           id="definicao"
-          class="content-section active bg-white p-6 rounded-lg shadow-md"
+          class="content-section bg-white p-6 rounded-lg shadow-md"
         >
           <h2 class="text-2xl font-semibold text-teal-600 mb-4">
             O que é a Distância de Hamming?
@@ -532,23 +488,6 @@
 
     <script>
       document.addEventListener("DOMContentLoaded", function () {
-        const tabs = document.querySelectorAll(".tab-button");
-        const contentSections = document.querySelectorAll(".content-section");
-
-        tabs.forEach((tab) => {
-          tab.addEventListener("click", () => {
-            tabs.forEach((t) => t.classList.remove("active"));
-            tab.classList.add("active");
-            const targetTab = tab.getAttribute("data-tab");
-            contentSections.forEach((section) => {
-              section.classList.remove("active");
-              if (section.id === targetTab) {
-                section.classList.add("active");
-              }
-            });
-          });
-        });
-
         document.getElementById("currentYear").textContent =
           new Date().getFullYear();
 

--- a/hellingerDistance.html
+++ b/hellingerDistance.html
@@ -14,19 +14,8 @@
       }
       @import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap");
 
-      .tab-button {
-        transition: all 0.3s ease;
-      }
-      .tab-button.active {
-        border-color: #0d9488; /* teal-600 */
-        color: #0d9488;
-        font-weight: 600;
-      }
       .content-section {
-        display: none;
-      }
-      .content-section.active {
-        display: block;
+        display: block; margin-bottom: 2rem;
       }
       .canvas-container {
         position: relative;
@@ -157,43 +146,10 @@
         </h1>
       </header>
 
-      <nav class="mb-8 flex flex-wrap justify-center gap-2 sm:gap-4">
-        <button
-          class="tab-button active py-2 px-4 border-b-2 border-transparent hover:border-teal-500 hover:text-teal-600 rounded-t-md"
-          data-tab="definicao"
-        >
-          Definição
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-teal-500 hover:text-teal-600 rounded-t-md"
-          data-tab="formula"
-        >
-          Fórmula e Termos
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-teal-500 hover:text-teal-600 rounded-t-md"
-          data-tab="intuicao"
-        >
-          Intuição e Vantagens
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-teal-500 hover:text-teal-600 rounded-t-md"
-          data-tab="aplicacoes"
-        >
-          Aplicações Práticas
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-teal-500 hover:text-teal-600 rounded-t-md"
-          data-tab="visualizador"
-        >
-          Visualizador Interativo
-        </button>
-      </nav>
-
       <main>
         <section
           id="definicao"
-          class="content-section active bg-white p-6 rounded-lg shadow-md"
+          class="content-section bg-white p-6 rounded-lg shadow-md"
         >
           <h2 class="text-2xl font-semibold text-teal-600 mb-4">
             O que é a Distância de Hellinger?
@@ -593,26 +549,6 @@
 
     <script>
       document.addEventListener("DOMContentLoaded", function () {
-        const tabs = document.querySelectorAll(".tab-button");
-        const contentSections = document.querySelectorAll(".content-section");
-
-        tabs.forEach((tab) => {
-          tab.addEventListener("click", () => {
-            tabs.forEach((t) => t.classList.remove("active"));
-            tab.classList.add("active");
-            const targetTab = tab.getAttribute("data-tab");
-            contentSections.forEach((section) => {
-              section.classList.remove("active");
-              if (section.id === targetTab) {
-                section.classList.add("active");
-              }
-            });
-            if (targetTab === "visualizador") {
-              updateChart();
-            }
-          });
-        });
-
         document.getElementById("currentYear").textContent =
           new Date().getFullYear();
 
@@ -750,6 +686,8 @@
         });
 
         calculateHellinger();
+        // Ensure chart is updated on initial load since visualizador is always active now
+        updateChart();
       });
     </script>
     <script>

--- a/jaccardDistance.html
+++ b/jaccardDistance.html
@@ -13,19 +13,8 @@
       }
       @import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap");
 
-      .tab-button {
-        transition: all 0.3s ease;
-      }
-      .tab-button.active {
-        border-color: #2563eb; /* blue-600 */
-        color: #2563eb;
-        font-weight: 600;
-      }
       .content-section {
-        display: none;
-      }
-      .content-section.active {
-        display: block;
+        display: block; margin-bottom: 2rem;
       }
       .formula {
         font-family: "Courier New", Courier, monospace;
@@ -133,43 +122,10 @@
         </h1>
       </header>
 
-      <nav class="mb-8 flex flex-wrap justify-center gap-2 sm:gap-4">
-        <button
-          class="tab-button active py-2 px-4 border-b-2 border-transparent hover:border-blue-500 hover:text-blue-600 rounded-t-md"
-          data-tab="definicao"
-        >
-          Definição
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-blue-500 hover:text-blue-600 rounded-t-md"
-          data-tab="formula"
-        >
-          Fórmula e Termos
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-blue-500 hover:text-blue-600 rounded-t-md"
-          data-tab="propriedades"
-        >
-          Propriedades
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-blue-500 hover:text-blue-600 rounded-t-md"
-          data-tab="aplicacoes"
-        >
-          Aplicações Práticas
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-blue-500 hover:text-blue-600 rounded-t-md"
-          data-tab="visualizador"
-        >
-          Visualizador Interativo
-        </button>
-      </nav>
-
       <main>
         <section
           id="definicao"
-          class="content-section active bg-white p-6 rounded-lg shadow-md"
+          class="content-section bg-white p-6 rounded-lg shadow-md"
         >
           <h2 class="text-2xl font-semibold text-blue-600 mb-4">
             O que é a Distância de Jaccard?
@@ -534,24 +490,6 @@
 
     <script>
       document.addEventListener("DOMContentLoaded", function () {
-        const tabs = document.querySelectorAll(".tab-button");
-        const contentSections = document.querySelectorAll(".content-section");
-
-        tabs.forEach((tab) => {
-          tab.addEventListener("click", () => {
-            tabs.forEach((t) => t.classList.remove("active"));
-            tab.classList.add("active");
-
-            const targetTab = tab.getAttribute("data-tab");
-            contentSections.forEach((section) => {
-              section.classList.remove("active");
-              if (section.id === targetTab) {
-                section.classList.add("active");
-              }
-            });
-          });
-        });
-
         document.getElementById("currentYear").textContent =
           new Date().getFullYear();
 

--- a/mahalanobisDistance.html
+++ b/mahalanobisDistance.html
@@ -18,19 +18,8 @@
       }
       @import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap");
 
-      .tab-button {
-        transition: all 0.3s ease;
-      }
-      .tab-button.active {
-        border-color: #0d9488; /* teal-600 */
-        color: #0d9488;
-        font-weight: 600;
-      }
       .content-section {
-        display: none;
-      }
-      .content-section.active {
-        display: block;
+        display: block; margin-bottom: 2rem;
       }
       .canvas-container {
         position: relative;
@@ -166,43 +155,10 @@
         </h1>
       </header>
 
-      <nav class="mb-8 flex flex-wrap justify-center gap-2 sm:gap-4">
-        <button
-          class="tab-button active py-2 px-4 border-b-2 border-transparent hover:border-teal-500 hover:text-teal-600 rounded-t-md"
-          data-tab="definicao"
-        >
-          Definição
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-teal-500 hover:text-teal-600 rounded-t-md"
-          data-tab="formula"
-        >
-          Fórmula e Termos
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-teal-500 hover:text-teal-600 rounded-t-md"
-          data-tab="intuicao"
-        >
-          Intuição e Vantagens
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-teal-500 hover:text-teal-600 rounded-t-md"
-          data-tab="aplicacoes"
-        >
-          Aplicações Práticas
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-teal-500 hover:text-teal-600 rounded-t-md"
-          data-tab="visualizador"
-        >
-          Visualizador Interativo
-        </button>
-      </nav>
-
       <main>
         <section
           id="definicao"
-          class="content-section active bg-white p-6 rounded-lg shadow-md"
+          class="content-section bg-white p-6 rounded-lg shadow-md"
         >
           <h2 class="text-2xl font-semibold text-teal-600 mb-4">
             O que é a Distância de Mahalanobis?
@@ -646,26 +602,6 @@
 
     <script>
       document.addEventListener("DOMContentLoaded", function () {
-        const tabs = document.querySelectorAll(".tab-button");
-        const contentSections = document.querySelectorAll(".content-section");
-
-        tabs.forEach((tab) => {
-          tab.addEventListener("click", () => {
-            tabs.forEach((t) => t.classList.remove("active"));
-            tab.classList.add("active");
-            const targetTab = tab.getAttribute("data-tab");
-            contentSections.forEach((section) => {
-              section.classList.remove("active");
-              if (section.id === targetTab) {
-                section.classList.add("active");
-              }
-            });
-            if (targetTab === "visualizador") {
-              requestAnimationFrame(() => sizeCanvasAndDraw());
-            }
-          });
-        });
-
         document.getElementById("currentYear").textContent =
           new Date().getFullYear();
 

--- a/manhattanDistance.html
+++ b/manhattanDistance.html
@@ -17,19 +17,8 @@
       }
       @import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap");
 
-      .tab-button {
-        transition: all 0.3s ease;
-      }
-      .tab-button.active {
-        border-color: #2563eb; /* blue-600 */
-        color: #2563eb;
-        font-weight: 600;
-      }
       .content-section {
-        display: none;
-      }
-      .content-section.active {
-        display: block;
+        display: block; margin-bottom: 2rem;
       }
       .canvas-container {
         position: relative;
@@ -157,43 +146,10 @@
         </h1>
       </header>
 
-      <nav class="mb-8 flex flex-wrap justify-center gap-2 sm:gap-4">
-        <button
-          class="tab-button active py-2 px-4 border-b-2 border-transparent hover:border-blue-500 hover:text-blue-600 rounded-t-md"
-          data-tab="definicao"
-        >
-          Definição
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-blue-500 hover:text-blue-600 rounded-t-md"
-          data-tab="formula"
-        >
-          Fórmula e Termos
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-blue-500 hover:text-blue-600 rounded-t-md"
-          data-tab="propriedades"
-        >
-          Propriedades
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-blue-500 hover:text-blue-600 rounded-t-md"
-          data-tab="aplicacoes"
-        >
-          Aplicações Práticas
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-blue-500 hover:text-blue-600 rounded-t-md"
-          data-tab="visualizador"
-        >
-          Visualizador Interativo
-        </button>
-      </nav>
-
       <main>
         <section
           id="definicao"
-          class="content-section active bg-white p-6 rounded-lg shadow-md"
+          class="content-section bg-white p-6 rounded-lg shadow-md"
         >
           <h2 class="text-2xl font-semibold text-blue-600 mb-4">
             O que é a Distância de Manhattan?
@@ -542,24 +498,6 @@
 
     <script>
       document.addEventListener("DOMContentLoaded", function () {
-        const tabs = document.querySelectorAll(".tab-button");
-        const contentSections = document.querySelectorAll(".content-section");
-
-        tabs.forEach((tab) => {
-          tab.addEventListener("click", () => {
-            tabs.forEach((t) => t.classList.remove("active"));
-            tab.classList.add("active");
-
-            const targetTab = tab.getAttribute("data-tab");
-            contentSections.forEach((section) => {
-              section.classList.remove("active");
-              if (section.id === targetTab) {
-                section.classList.add("active");
-              }
-            });
-          });
-        });
-
         document.getElementById("currentYearManhattan").textContent =
           new Date().getFullYear();
 

--- a/minkowskiDistance.html
+++ b/minkowskiDistance.html
@@ -18,19 +18,8 @@
       }
       @import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap");
 
-      .tab-button {
-        transition: all 0.3s ease;
-      }
-      .tab-button.active {
-        border-color: #0d9488; /* teal-600 */
-        color: #0d9488;
-        font-weight: 600;
-      }
       .content-section {
-        display: none;
-      }
-      .content-section.active {
-        display: block;
+        display: block; margin-bottom: 2rem;
       }
       .formula {
         font-family: "Consolas", "Courier New", Courier, monospace;
@@ -161,49 +150,10 @@
         </h1>
       </header>
 
-      <nav class="mb-8 flex flex-wrap justify-center gap-2 sm:gap-4">
-        <button
-          class="tab-button active py-2 px-4 border-b-2 border-transparent hover:border-teal-500 hover:text-teal-600 rounded-t-md"
-          data-tab="definicao"
-        >
-          Definição
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-teal-500 hover:text-teal-600 rounded-t-md"
-          data-tab="formula"
-        >
-          Fórmula
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-teal-500 hover:text-teal-600 rounded-t-md"
-          data-tab="casos_especiais"
-        >
-          Casos Especiais
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-teal-500 hover:text-teal-600 rounded-t-md"
-          data-tab="parametro_p"
-        >
-          Parâmetro 'p'
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-teal-500 hover:text-teal-600 rounded-t-md"
-          data-tab="aplicacoes"
-        >
-          Aplicações Práticas
-        </button>
-        <button
-          class="tab-button py-2 px-4 border-b-2 border-transparent hover:border-teal-500 hover:text-teal-600 rounded-t-md"
-          data-tab="visualizador"
-        >
-          Visualizador Interativo
-        </button>
-      </nav>
-
       <main>
         <section
           id="definicao"
-          class="content-section active bg-white p-6 rounded-lg shadow-md"
+          class="content-section bg-white p-6 rounded-lg shadow-md"
         >
           <h2 class="text-2xl font-semibold text-teal-600 mb-4">
             O que é a Distância de Minkowski?
@@ -621,26 +571,6 @@
 
     <script>
       document.addEventListener("DOMContentLoaded", function () {
-        const tabs = document.querySelectorAll(".tab-button");
-        const contentSections = document.querySelectorAll(".content-section");
-
-        tabs.forEach((tab) => {
-          tab.addEventListener("click", () => {
-            tabs.forEach((t) => t.classList.remove("active"));
-            tab.classList.add("active");
-            const targetTab = tab.getAttribute("data-tab");
-            contentSections.forEach((section) => {
-              section.classList.remove("active");
-              if (section.id === targetTab) {
-                section.classList.add("active");
-              }
-            });
-            if (targetTab === "visualizador") {
-              requestAnimationFrame(() => sizeCanvasAndDrawMinkowski());
-            }
-          });
-        });
-
         document.getElementById("currentYear_mink").textContent =
           new Date().getFullYear();
 
@@ -901,12 +831,11 @@
 
         window.addEventListener("resize", sizeCanvasAndDrawMinkowski);
 
-        if (
-          document.getElementById("visualizador").classList.contains("active")
-        ) {
-          requestAnimationFrame(() => sizeCanvasAndDrawMinkowski());
-        } else {
-          const p1x_val = parseFloat(p1xInput.value);
+        // Ensure canvas is drawn on initial load as sections are now always visible
+        requestAnimationFrame(() => sizeCanvasAndDrawMinkowski());
+        // The following block is not strictly necessary anymore as the visualizador section is always "active"
+        // However, keeping it doesn't harm, and ensures the initial calculation if needed for some reason.
+        const p1x_val = parseFloat(p1xInput.value);
           const p1y_val = parseFloat(p1yInput.value);
           const p2x_val = parseFloat(p2xInput.value);
           const p2y_val = parseFloat(p2yInput.value);


### PR DESCRIPTION
I've consolidated the content of each distance-specific page (e.g., Euclidean, Manhattan, etc.) into a single, scrollable landing page for you.

- I removed the HTML, CSS, and JavaScript related to the tab functionality.
- I ensured all content sections (definition, formula, visualizer, etc.) are displayed by default.
- I adjusted the visualizers on the affected pages so they initialize correctly in the new layout.